### PR TITLE
add player level to irc chat

### DIFF
--- a/src/plugins/chat/external.chat.irc.js
+++ b/src/plugins/chat/external.chat.irc.js
@@ -41,6 +41,6 @@ export class ExternalChatMechanism {
 
   sendMessage(msgData) {
     if(!isProd || !this.isConnected) return;
-    this.client.msg(channel, `<web:${msgData.playerName}> ${msgData.text}`);
+    this.client.msg(channel, `<web:${msgData.playerName} [${msgData.level}]> ${msgData.text}`);
   }
 }

--- a/src/plugins/chat/sendmessage.socket.js
+++ b/src/plugins/chat/sendmessage.socket.js
@@ -51,7 +51,7 @@ export const socket = (socket, primus) => {
     text = _.truncate(text, { length: SETTINGS.chatMessageMaxLength, omission: ' [truncated]' }).trim();
     if(!text) return;
 
-    const messageObject = { text, timestamp, channel, route, title: player.title, playerName: player.nameEdit ? player.nameEdit : player.name, event };
+    const messageObject = { text, timestamp, channel, route, title: player.title, playerName: player.nameEdit ? player.nameEdit : player.name, level: player.level, event };
 
     if(_.includes(route, ':pm:')) {
       const users = route.split(':')[2].split('|');


### PR DESCRIPTION
Puts the player level into the irc chat, by their name. Helpful for
identifying extent of advice required in response to the many ambiguous
questions.