### PR TITLE
Stop player stats saving twice

### DIFF
--- a/src/plugins/players/player.js
+++ b/src/plugins/players/player.js
@@ -222,7 +222,7 @@ export class Player extends Character {
       `Character.Maps.${this.map}`,
       `Character.Terrains.${tile.terrain}`,
       `Character.Regions.${tile.region}`
-    ]);
+    ], false);
 
     this.gainXp(SETTINGS.xpPerStep);
   }

--- a/src/plugins/statistics/statistics.js
+++ b/src/plugins/statistics/statistics.js
@@ -46,9 +46,11 @@ export class Statistics {
     this.save();
   }
 
-  batchIncrement(stats) {
+  batchIncrement(stats, doSave = true) {
     _.each(stats, stat => this._addStat(stat));
-    this.save();
+    if (doSave) {
+      this.save();
+    }
   }
 
   save() {

--- a/test/client/client.js
+++ b/test/client/client.js
@@ -1,4 +1,5 @@
 
+require('babel-register');
 require('babel-polyfill');
 
 const _ = require('lodash');


### PR DESCRIPTION
Adds “doSave” flag to stats.batchIncrement. Since we do an XP update
right after (both of which save stats by default), the update can save,
not the batch increment.