### PR TITLE
check for env file

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ if(process.env.NODE_ENV === 'production' && !process.env.IGNORE_NEWRELIC) {
 
 var fs = require('fs');
 try {
-    fs.accessSync('./.env', fs.F_OK);
+    // production passes in environment variables instead
+    if(process.env.NODE_ENV !== 'production') {
+    	fs.accessSync('./.env', fs.F_OK);
+    }
 } catch (e) {
     console.log('Can\'t find the .env file. Please place one in the current dir');
     process.exit();

--- a/index.js
+++ b/index.js
@@ -3,6 +3,14 @@ if(process.env.NODE_ENV === 'production' && !process.env.IGNORE_NEWRELIC) {
   require('newrelic');
 }
 
+var fs = require('fs');
+try {
+    fs.accessSync('./.env', fs.F_OK);
+} catch (e) {
+    console.log('Can\'t find the .env file. Please place one in the current dir');
+    process.exit();
+}
+
 process.on('uncaughtException', e => console.error(e));
 process.on('unhandledRejection', reason => console.error(reason));
 


### PR DESCRIPTION
just checks for an .env file at startup. Alerts user and exits if not
found (better than the confusing error messages that otherwise spew out)