### PR TITLE
return player count externally

### DIFF
--- a/primus/server.js
+++ b/primus/server.js
@@ -27,7 +27,7 @@ export const primus = (() => {
   const serve = express();
   serve.use(compression(), express.static('assets'));
   serve.get('/online', (req, res) => {
-    res.send('ok');
+    res.send(`${GameState.getInstance().getPlayers().length}`);
   });
   const finalhandler = require('finalhandler');
 


### PR DESCRIPTION
Hopefully this will force the internal broken game state to be visible
externally, so we can auto-reboot when things are dead.