### PR TITLE
Move primus to /src

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,6 @@ require('dotenv').config({ silent: true });
 require('babel-register');
 require('babel-polyfill');
 
-require('./primus/server');
+require('./src/primus/server');
 
 require('./src/core/event-loop');

--- a/src/plugins/events/event.js
+++ b/src/plugins/events/event.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import { StringAssets } from '../../shared/asset-loader';
 import { MessageParser } from '../../plugins/events/messagecreator';
 
-import { primus } from '../../../primus/server';
+import { primus } from '../../primus/server';
 
 import { emitter } from '../../plugins/players/_emitter';
 

--- a/src/primus/server.js
+++ b/src/primus/server.js
@@ -5,10 +5,10 @@ import _ from 'lodash';
 import Primus from 'primus';
 import Emit from 'primus-emit';
 import Rooms from 'primus-rooms';
-import Multiplex from 'primus-multiplex';
+// import Multiplex from 'primus-multiplex';
 
-import { GameState } from '../src/core/game-state';
-import { Logger } from '../src/shared/logger';
+import { GameState } from '../core/game-state';
+import { Logger } from '../shared/logger';
 
 export const primus = (() => {
   if(process.env.NO_START_GAME) return;
@@ -52,7 +52,7 @@ export const primus = (() => {
   const primus = new Primus(server, { iknowhttpsisbetter: true, parser: 'JSON', transformer: 'websockets' });
 
 // load socket functions
-  const normalizedPath = require('path').join(__dirname, '..', 'src');
+  const normalizedPath = require('path').join(__dirname, '..');
 
   const getAllSocketFunctions = (dir) => {
     let results = [];
@@ -76,7 +76,7 @@ export const primus = (() => {
   // primus.use('multiplex', Multiplex);
 
 // force setting up the global connection
-  new (require('../src/shared/db-wrapper').DbWrapper)().connectionPromise();
+  new (require('../shared/db-wrapper').DbWrapper)().connectionPromise();
 
   primus.on('connection', spark => {
     const respond = (data) => {

--- a/src/shared/adventure-log.js
+++ b/src/shared/adventure-log.js
@@ -2,7 +2,7 @@
 import _ from 'lodash';
 
 import { Logger } from './logger';
-import { primus } from '../../primus/server';
+import { primus } from '../primus/server';
 
 const verifyMessage = (msg) => {
   if(!msg.type)

--- a/src/shared/data-updater.js
+++ b/src/shared/data-updater.js
@@ -1,7 +1,7 @@
 
 export const DataUpdater = (playerName, type, data) => {
   // Would initialise server with testing if imported on top.
-  const primus = require('../../primus/server').primus;
+  const primus = require('../primus/server').primus;
 
   primus.forEach(spark => {
     if(!spark.authToken || spark.authToken.playerName !== playerName) return;

--- a/src/shared/playerlist-updater.js
+++ b/src/shared/playerlist-updater.js
@@ -1,7 +1,7 @@
 
 import _ from 'lodash';
 
-import { primus } from '../../primus/server';
+import { primus } from '../primus/server';
 import { GameState } from '../core/game-state';
 
 // these functions pertain to one person logging in and out


### PR DESCRIPTION
Move primus dir into src, so we can get rid of babel-register on
production (very slow, not recommended). Also commented out primus
Multiplex (since it’s not used)