### PR TITLE
Asset loader use relative path

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "gitfix"
   ],
   "dependencies": {
-    "app-root-path": "^1.2.1",
     "babel-plugin-transform-async-to-generator": "^6.8.0",
     "babel-plugin-transform-class-properties": "^6.10.2",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",

--- a/src/shared/asset-loader.js
+++ b/src/shared/asset-loader.js
@@ -1,7 +1,6 @@
 
 import fs from 'fs';
 import _ from 'lodash';
-import appRootPath from 'app-root-path';
 
 // auto-populated
 export const StringAssets = {};
@@ -87,7 +86,7 @@ const parseFile = (filename) => {
   return _(baseContents).compact() /* .reject(line => _.includes(line, '#')) */ .value();
 };
 
-StringAssets.class = _.map(loadDirectory(`${appRootPath}/src/core/professions`), ({ filename }) => {
+StringAssets.class = _.map(loadDirectory(`${__dirname}/../core/professions`), ({ filename }) => {
   const split = filename.split('/');
   return split[split.length - 1].split('.')[0];
 });


### PR DESCRIPTION
Switched to relative path (so we can transpile from src->dist). Since
not using app-root-path any more, removed it from package.json (did npm
prune & tested. All ok)