### PR TITLE
improve bless/forsake event output

### DIFF
--- a/src/plugins/events/events/GoldBless.js
+++ b/src/plugins/events/events/GoldBless.js
@@ -17,7 +17,7 @@ export class GoldBless extends Event {
     const goldMod = Math.floor(Event.chance.integer({ min: 10, max: 1000 }));
     const eventText = this.eventText('blessGold', player, { gold: goldMod });
 
-    this.emitMessage({ affected: [player], eventText: `${eventText} [+${goldMod}gold]`, category: MessageCategories.GOLD });
+    this.emitMessage({ affected: [player], eventText: `${eventText} [+${goldMod} gold]`, category: MessageCategories.GOLD });
     player.gainGold(goldMod);
   }
 }

--- a/src/plugins/events/events/GoldBlessParty.js
+++ b/src/plugins/events/events/GoldBlessParty.js
@@ -11,7 +11,7 @@ export class GoldBlessParty extends Event {
     const goldMod = Math.floor(Event.chance.integer({ min: 10, max: 1000 }));
     const eventText = this.eventText('blessGoldParty', player, { gold: goldMod, partyName: player.party.name });
 
-    this.emitMessage({ affected: player.party.players, eventText: `${eventText} [+${goldMod}gold]`, category: MessageCategories.GOLD });
+    this.emitMessage({ affected: player.party.players, eventText: `${eventText} [+${goldMod} gold]`, category: MessageCategories.GOLD });
 
     _.each(player.party.players, member => {
       member.gainGold(goldMod);

--- a/src/plugins/events/events/GoldForsake.js
+++ b/src/plugins/events/events/GoldForsake.js
@@ -10,7 +10,7 @@ export class GoldForsake extends Event {
     const goldMod = Math.min(player.gold, Math.floor(Event.chance.integer({ min: 25, max: 2000 })));
     const eventText = this.eventText('forsakeGold', player, { gold: goldMod });
 
-    this.emitMessage({ affected: [player], eventText: `${eventText} [-${goldMod}gold]`, category: MessageCategories.GOLD });
+    this.emitMessage({ affected: [player], eventText: `${eventText} [-${goldMod} gold]`, category: MessageCategories.GOLD });
     player.gainGold(-goldMod);
   }
 }

--- a/src/plugins/events/events/XPBless.js
+++ b/src/plugins/events/events/XPBless.js
@@ -18,7 +18,7 @@ export class XPBless extends Event {
     const xpMod = Math.floor(player._xp.maximum * percent);
     const eventText = this.eventText('blessXp', player, { xp: xpMod });
 
-    this.emitMessage({ affected: [player], eventText: `${eventText} [+${xpMod}xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
+    this.emitMessage({ affected: [player], eventText: `${eventText} [+${xpMod} xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
     player.gainXp(xpMod);
   }
 }

--- a/src/plugins/events/events/XPBlessParty.js
+++ b/src/plugins/events/events/XPBlessParty.js
@@ -12,7 +12,7 @@ export class XPBlessParty extends Event {
     const xpMod = Math.floor(player._xp.maximum * percent);
     const eventText = this.eventText('blessXpParty', player, { xp: xpMod, partyName: player.party.name });
 
-    this.emitMessage({ affected: player.party.players, eventText: `${eventText} [+${xpMod}xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
+    this.emitMessage({ affected: player.party.players, eventText: `${eventText} [+${xpMod} xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
 
     _.each(player.party.players, member => {
       member.gainXp(xpMod);

--- a/src/plugins/events/events/XPForsake.js
+++ b/src/plugins/events/events/XPForsake.js
@@ -11,7 +11,7 @@ export class XPForsake extends Event {
     const xpMod = Math.floor(player._xp.maximum * percent);
     const eventText = this.eventText('forsakeXp', player, { xp: xpMod });
 
-    this.emitMessage({ affected: [player], eventText: `${eventText} [-${xpMod}xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
+    this.emitMessage({ affected: [player], eventText: `${eventText} [-${xpMod} xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
     player.gainXp(-xpMod);
   }
 }


### PR DESCRIPTION
78gold -> 78 gold. 84xp -> 84 xp. Just put a space between quantity and
descriptive, so it’s a little clearer to read (plus consistent with
elsewhere)