### PR TITLE
Dist test in place for travis deploy

### DIFF
--- a/src/primus/server.js
+++ b/src/primus/server.js
@@ -39,6 +39,13 @@ export const primus = (() => {
       res.send(e);
     }
   });
+  serve.get('/hello', (req, res) => {
+    try {
+      res.send(fs.readFileSync('../../dist/hello.txt', 'UTF-8'));
+    } catch (e) {
+      res.send(e);
+    }
+  });
   const finalhandler = require('finalhandler');
 
 // load primus


### PR DESCRIPTION
Reads dist/hello.txt - just a dummy file we can get travis to put
there, to test whether our travis deploy is working properly, and will,
for removal of babel-register. Failure is expected return val (until we
de-kink travis)