### PR TITLE
Prepare git for deployment of dist

### DIFF
--- a/scripts/prodprep.sh
+++ b/scripts/prodprep.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# change to root
+cd ..
+
+# obviously we could also put our babel command in here, to create the dist subtree, thusly:
+#babel -q --compact true --minified -d dist src
+
+# but for now...
+# put a temp file in there, for the /hello endpoint (so we know it's all working)
+echo 'hello' dist/hello.txt
+
+# delete the dist line from .gitignore, so git->heroku will auto pick up the dist dir
+sed -i '' '/dist/d' .gitignore
+


### PR DESCRIPTION
trim .gitignore so git->heroic will grab the dist directory. For test
(right now) just dump a basic file into /dist. Later, can run babel
command from here too