### PR TITLE
Clerics only heal health   80%

### DIFF
--- a/src/plugins/combat/spells/Cure.js
+++ b/src/plugins/combat/spells/Cure.js
@@ -15,7 +15,7 @@ export class Cure extends Spell {
   ];
 
   static shouldCast(caster) {
-    return this.$canTarget.allyBelowMaxHealth(caster);
+    return this.$canTarget.allyBelowHealthPercent(caster, 0.8);
   }
 
   calcDamage() {
@@ -25,7 +25,7 @@ export class Cure extends Spell {
   }
 
   determineTargets() {
-    return this.$targetting.randomAllyBelowMaxHealth;
+    return this.$targetting.randomAllyBelowHealthPercent(0.8);
   }
 
   preCast() {

--- a/src/plugins/combat/spells/Cure.js
+++ b/src/plugins/combat/spells/Cure.js
@@ -15,7 +15,7 @@ export class Cure extends Spell {
   ];
 
   static shouldCast(caster) {
-    return this.$canTarget.allyBelowHealthPercent(caster, 0.8);
+    return this.$canTarget.allyBelowHealthPercent(caster, 80);
   }
 
   calcDamage() {
@@ -25,7 +25,7 @@ export class Cure extends Spell {
   }
 
   determineTargets() {
-    return this.$targetting.randomAllyBelowHealthPercent(0.8);
+    return this.$targetting.randomAllyBelowHealthPercent(80);
   }
 
   preCast() {

--- a/src/plugins/combat/spelltargetpossibilities.js
+++ b/src/plugins/combat/spelltargetpossibilities.js
@@ -44,6 +44,14 @@ export class SpellTargetPossibilities {
         .value().length >= 1;
   }
 
+  static allyBelowHealthPercent(caster, percent) {
+    return _(caster.$battle.allPlayers)
+        .reject(p => p.hp === 0)
+        .reject(p => p.party !== caster.party)
+      .reject(p => p._hp.greaterThanPercent(percent))
+        .value().length >= 1;
+  }
+
   static allyBelowMaxHealth(caster) {
     return _(caster.$battle.allPlayers)
         .reject(p => p.hp === 0)

--- a/src/plugins/combat/spelltargetpossibilities.js
+++ b/src/plugins/combat/spelltargetpossibilities.js
@@ -48,7 +48,7 @@ export class SpellTargetPossibilities {
     return _(caster.$battle.allPlayers)
         .reject(p => p.hp === 0)
         .reject(p => p.party !== caster.party)
-      .reject(p => p._hp.greaterThanPercent(percent))
+        .reject(p => p._hp.greaterThanPercent(percent))
         .value().length >= 1;
   }
 

--- a/src/plugins/combat/spelltargetstrategy.js
+++ b/src/plugins/combat/spelltargetstrategy.js
@@ -89,6 +89,14 @@ export class SpellTargetStrategy {
       .sample()];
   }
 
+  static randomAllyBelowHealthPercent(caster, percent) {
+    return [_(caster.$battle.allPlayers)
+      .reject(p => p.hp === 0)
+      .reject(p => p.party !== caster.party)
+      .reject(p => p._hp.greaterThanPercent(percent))
+      .sample()];
+  }
+
   static randomAllyBelowMaxHealth(caster) {
     return [_(caster.$battle.allPlayers)
       .reject(p => p.hp === 0)


### PR DESCRIPTION
Make Clerics more aggressive (for faster more interesting battles).
Added allyBelowHealthPercent and randomAllyBelowHealthPercent functions
for general use (currently only Cure uses these, but similar could also be used
to attack dying targets etc). 80% cut off is arbitrary, but no point
wasting a round healing someone who’s only 2% sick.