### PR TITLE
Add random 5 digit number to battle timestamp

### DIFF
--- a/src/plugins/combat/battle.js
+++ b/src/plugins/combat/battle.js
@@ -17,7 +17,10 @@ export class Battle {
   constructor({ parties, introText }) {
     this.parties = parties;
     this.introText = introText;
-    this.happenedAt = Date.now();
+    // 5 digit number from 10000->99999 inclusive
+    // Math.floor(Math.random()*(max-min+1)+min)
+    const salt = Math.floor(Math.random()*90000+10000)
+    this.happenedAt = `${Date.now()}${salt}`;
     this.name = this.generateName();
     this.setId();
     this.messageData = [];


### PR DESCRIPTION
This should help prevent collisions. When we get 100k battles in a
millisecond we can revist. this.happenedAt is only ever used in
strings, so converting it to a string from a numeric timestamp is safe.