### PR TITLE
Make statistics save respect saveSteps

### DIFF
--- a/src/plugins/combat/battle.js
+++ b/src/plugins/combat/battle.js
@@ -292,6 +292,9 @@ export class Battle {
       p.$battle = null;
       p.$profession.resetSpecial(p);
       p.$effects.clear();
+      if (p.$statistics) {
+        p.$statistics.save();
+      }
 
       if(p.isPet) {
         p.party.playerLeave(p);

--- a/src/plugins/players/player.js
+++ b/src/plugins/players/player.js
@@ -223,7 +223,7 @@ export class Player extends Character {
       incrementStats.push('Character.Movement.Drunk');
     }
 
-    this.$statistics.batchIncrement(incrementStats, false);
+    this.$statistics.batchIncrement(incrementStats);
 
     this.gainXp(SETTINGS.xpPerStep);
   }
@@ -247,6 +247,7 @@ export class Player extends Character {
 
     if(this.saveSteps <= 0) {
       this.$playerDb.savePlayer(this);
+      this.$statistics.save();
       this.saveSteps = SETTINGS.saveSteps;
     }
     this.update();

--- a/src/plugins/statistics/statistics.js
+++ b/src/plugins/statistics/statistics.js
@@ -41,12 +41,14 @@ export class Statistics {
     return _.sum(_.values(obj)) || 0;
   }
 
-  incrementStat(stat, value = 1) {
+  incrementStat(stat, value = 1, doSave = false) {
     this._addStat(stat, value);
-    this.save();
+    if (doSave) {
+      this.save();
+    }
   }
 
-  batchIncrement(stats, doSave = true) {
+  batchIncrement(stats, doSave = false) {
     _.each(stats, stat => this._addStat(stat));
     if (doSave) {
       this.save();


### PR DESCRIPTION
Stop stats saving on every increment (esp bad during battles -
gainXp();gainGold() —> two saves). Default to NOT save on increments.
Manually save during regular saveSteps player save.