### PR TITLE
Simplify prod prep

### DIFF
--- a/scripts/prod-cleanup.sh
+++ b/scripts/prod-cleanup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-mv .gitignore.bak .gitignore
+#nothing here right now, but we could use this later
+#mv .gitignore.bak .gitignore

--- a/scripts/prod-prep.sh
+++ b/scripts/prod-prep.sh
@@ -11,5 +11,5 @@
 echo 'hello' > dist/hello.txt
 
 # delete the dist line from .gitignore, so git->heroku will auto pick up the dist dir
-sed -i.bak '/dist/d' .gitignore
+# sed -i.bak '/dist/d' .gitignore
 


### PR DESCRIPTION
the copy across is done before this script can run, so changing the
.gitignore has no effect. I suspect we may not need to.