### PR TITLE
Create dist dir in container

### DIFF
--- a/scripts/prod-prep.sh
+++ b/scripts/prod-prep.sh
@@ -8,7 +8,8 @@
 
 # but for now...
 # put a temp file in there, for the /hello endpoint (so we know it's all working)
-echo 'hello' > dist/hello.txt
+mkdir dist
+echo hello > dist/hello.txt
 
 # delete the dist line from .gitignore, so git->heroku will auto pick up the dist dir
 sed -i.bak '/dist/d' .gitignore


### PR DESCRIPTION
since dist is ignored by .gitignore, it’s likely not created by the
initial clone, therefore we need to create it before we can put
anything in it.