### PR TITLE
Temp remove /hello

### DIFF
--- a/src/primus/server.js
+++ b/src/primus/server.js
@@ -39,14 +39,14 @@ export const primus = (() => {
       res.send(e);
     }
   });
-  serve.get('/hello', (req, res) => {
-    try {
-      const test = require('../../dist/test.js');
-      res.send(test.output());
-    } catch (e) {
-      res.send(e);
-    }
-  });
+  // serve.get('/hello', (req, res) => {
+  //   try {
+  //     const test = require('../../dist/test.js');
+  //     res.send(test.output());
+  //   } catch (e) {
+  //     res.send(e);
+  //   }
+  // });
   const finalhandler = require('finalhandler');
 
 // load primus


### PR DESCRIPTION
Since our rollbar errors are getting close to max for the month
(without paying), on the off chance this is what’s causing those weird
Receiver errors, have commented it out until I’m more actively working
on Travis.

At this point, I’m still mulling possibilities, and focused on other
stuff. Suspect it might be a wandering search engine hitting this end
point & causing problems. Maybe.