### PR TITLE
Make achievement text easier to read

### DIFF
--- a/src/plugins/achievements/achievements/Bossy.js
+++ b/src/plugins/achievements/achievements/Bossy.js
@@ -29,7 +29,7 @@ export class Bossy extends Achievement {
     return [{
       tier,
       name: 'Bossy',
-      desc: `+${tier*10} STR/CON for killing ${baseValue*tier} bosses.`,
+      desc: `+${(tier*10).toLocaleString()} STR/CON for killing ${baseValue*tier} bosses.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Boxer.js
+++ b/src/plugins/achievements/achievements/Boxer.js
@@ -29,7 +29,7 @@ export class Boxer extends Achievement {
     return [{
       tier,
       name: 'Boxer',
-      desc: `+${tier*10} DEX/AGI for opening ${baseValue*tier} chests.`,
+      desc: `+${(tier*10).toLocaleString()} DEX/AGI for opening ${baseValue*tier} chests.`,
       type: AchievementTypes.EXPLORE,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Camper.js
+++ b/src/plugins/achievements/achievements/Camper.js
@@ -11,7 +11,7 @@ export class Camper extends Achievement {
     return [{
       tier: 1,
       name: 'Camper',
-      desc: 'Gain a special title for camping for 100000 steps.',
+      desc: `Gain a special title for camping for ${(100000).toLocaleString()} steps.`,
       type: AchievementTypes.EXPLORE,
       rewards: [{
         type: 'title',

--- a/src/plugins/achievements/achievements/Consumerist.js
+++ b/src/plugins/achievements/achievements/Consumerist.js
@@ -30,7 +30,7 @@ export class Consumerist extends Achievement {
     return [{
       tier,
       name: 'Consumerist',
-      desc: `Sell items for ${tier*5}% more for spending ${baseValue * Math.pow(10, tier-1)} gold, and gain +${tier}% DEX.`,
+      desc: `Sell items for ${(tier*5).toLocaleString()}% more for spending ${(baseValue * Math.pow(10, tier-1)).toLocaleString()} gold, and gain +${tier}% DEX.`,
       type: AchievementTypes.EVENT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Critical.js
+++ b/src/plugins/achievements/achievements/Critical.js
@@ -29,7 +29,7 @@ export class Critical extends Achievement {
     return [{
       tier,
       name: 'Critical',
-      desc: `Gain ${tier}% DEX for having ${tier*50} critical hits.`,
+      desc: `Gain ${tier}% DEX for having ${(tier*50).toLocaleString()} critical hits.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/DigitalMagician.js
+++ b/src/plugins/achievements/achievements/DigitalMagician.js
@@ -11,7 +11,7 @@ export class DigitalMagician extends Achievement {
     return [{
       tier: 1,
       name: 'Digital Magician',
-      desc: 'Gain a special title for 100000 Digital skill uses.',
+      desc: `Gain a special title for ${(100000).toLocaleString()} Digital skill uses.`,
       type: AchievementTypes.COMBAT,
       rewards: [{
         type: 'title',

--- a/src/plugins/achievements/achievements/Drunk.js
+++ b/src/plugins/achievements/achievements/Drunk.js
@@ -11,7 +11,7 @@ export class Drunk extends Achievement {
     return [{
       tier: 1,
       name: 'Drunk',
-      desc: 'Gain a special title for 100000 drunken steps.',
+      desc: `Gain a special title for ${(100000).toLocaleString()} drunken steps.`,
       type: AchievementTypes.EXPLORE,
       rewards: [{
         type: 'title',

--- a/src/plugins/achievements/achievements/Effective.js
+++ b/src/plugins/achievements/achievements/Effective.js
@@ -29,7 +29,7 @@ export class Effective extends Achievement {
     return [{
       tier,
       name: 'Effective',
-      desc: `+${tier}% MP for ${tier*200} combat effect usages.`,
+      desc: `+${tier}% MP for ${(tier*200).toLocaleString()} combat effect usages.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Eventful.js
+++ b/src/plugins/achievements/achievements/Eventful.js
@@ -28,7 +28,7 @@ export class Eventful extends Achievement {
     return [{
       tier,
       name: 'Eventful',
-      desc: `Equip items that are ${10*tier}% better for experiencing ${baseValue * Math.pow(10, tier)} events.`,
+      desc: `Equip items that are ${(10*tier).toLocaleString()}% better for experiencing ${(baseValue * Math.pow(10, tier)).toLocaleString()} events.`,
       type: AchievementTypes.EVENT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Explorative.js
+++ b/src/plugins/achievements/achievements/Explorative.js
@@ -30,7 +30,7 @@ export class Explorative extends Achievement {
     return [{
       tier,
       name: 'Explorative',
-      desc: `Gain +${tier}% INT for exploring ${tier*5} unique maps.`,
+      desc: `Gain +${tier}% INT for exploring ${(tier*5).toLocaleString()} unique maps.`,
       type: AchievementTypes.EXPLORE,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Golden.js
+++ b/src/plugins/achievements/achievements/Golden.js
@@ -30,7 +30,7 @@ export class Golden extends Achievement {
     return [{
       tier,
       name: 'Golden',
-      desc: `Sell items for ${tier*5}% more for gaining and losing at least ${baseValue * Math.pow(10, tier-1)} gold, and +${tier}% AGI.`,
+      desc: `Sell items for ${(tier*5).toLocaleString()}% more for gaining and losing at least ${(baseValue * Math.pow(10, tier-1)).toLocaleString()} gold, and +${tier}% AGI.`,
       type: AchievementTypes.EVENT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Levelable.js
+++ b/src/plugins/achievements/achievements/Levelable.js
@@ -23,7 +23,7 @@ export class Levelable extends Achievement {
     return [{
       tier,
       name: 'Levelable',
-      desc: `Gain +${tier} LUK and +${tier} Bonus XP (added every time XP is gained) for being level ${tier*10}.`,
+      desc: `Gain +${tier} LUK and +${tier} Bonus XP (added every time XP is gained) for being level ${(tier*10).toLocaleString()}.`,
       type: AchievementTypes.PROGRESS,
       rewards
     }];

--- a/src/plugins/achievements/achievements/PKer.js
+++ b/src/plugins/achievements/achievements/PKer.js
@@ -33,7 +33,7 @@ export class PKer extends Achievement {
     return [{
       tier,
       name: 'PKer',
-      desc: `Gain +${tier*5} STR/CON/DEX/INT/AGI and +${tier*10}% better item find for killing ${baseValue * Math.pow(10, tier-1)} players.`,
+      desc: `Gain +${(tier*5).toLocaleString()} STR/CON/DEX/INT/AGI and +${(tier*10).toLocaleString()}% better item find for killing ${(baseValue * Math.pow(10, tier-1)).toLocaleString()} players.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Slayer.js
+++ b/src/plugins/achievements/achievements/Slayer.js
@@ -33,7 +33,7 @@ export class Slayer extends Achievement {
     return [{
       tier,
       name: 'Slayer',
-      desc: `Gain +${tier*5} STR/CON/DEX/INT/AGI and +${tier*10}% better item find for killing ${baseValue * Math.pow(10, tier-1)} monsters.`,
+      desc: `Gain +${(tier*5).toLocaleString()} STR/CON/DEX/INT/AGI and +${(tier*10).toLocaleString()}% better item find for killing ${(baseValue * Math.pow(10, tier-1)).toLocaleString()} monsters.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/SoleFoot.js
+++ b/src/plugins/achievements/achievements/SoleFoot.js
@@ -11,7 +11,7 @@ export class SoleFoot extends Achievement {
     return [{
       tier: 1,
       name: 'Sole Foot',
-      desc: 'Gain a special title for taking 100000 solo steps.',
+      desc: `Gain a special title for taking ${(100000).toLocaleString()} solo steps.`,
       type: AchievementTypes.EXPLORE,
       rewards: [{
         type: 'title',

--- a/src/plugins/achievements/achievements/Soloer.js
+++ b/src/plugins/achievements/achievements/Soloer.js
@@ -11,7 +11,7 @@ export class Soloer extends Achievement {
     return [{
       tier: 1,
       name: 'Soloer',
-      desc: 'Gain a special title for 5000 solo battles.',
+      desc: `Gain a special title for ${(5000).toLocaleString()} solo battles.`,
       type: AchievementTypes.COMBAT,
       rewards: [{
         type: 'title',

--- a/src/plugins/achievements/achievements/Sponge.js
+++ b/src/plugins/achievements/achievements/Sponge.js
@@ -30,7 +30,7 @@ export class Sponge extends Achievement {
     return [{
       tier,
       name: 'Sponge',
-      desc: `Gain +${tier}% HP and +${tier*20} CON for taking ${baseValue * Math.pow(10, tier-1)} damage.`,
+      desc: `Gain +${tier}% HP and +${(tier*20).toLocaleString()} CON for taking ${(baseValue * Math.pow(10, tier-1)).toLocaleString()} damage.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Territorial.js
+++ b/src/plugins/achievements/achievements/Territorial.js
@@ -30,7 +30,7 @@ export class Territorial extends Achievement {
     return [{
       tier,
       name: 'Territorial',
-      desc: `Gain +${tier}% STR for every ${tier*10} unique regions explored.`,
+      desc: `Gain +${tier}% STR for every ${(tier*10).toLocaleString()} unique regions explored.`,
       type: AchievementTypes.EXPLORE,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Unstoppable.js
+++ b/src/plugins/achievements/achievements/Unstoppable.js
@@ -30,7 +30,7 @@ export class Unstoppable extends Achievement {
     return [{
       tier,
       name: 'Unstoppable',
-      desc: `Gain +${tier}% HP and +${20*tier} STR for dealing ${baseValue * Math.pow(10, tier-1)} damage.`,
+      desc: `Gain +${tier}% HP and +${(20*tier).toLocaleString()} STR for dealing ${(baseValue * Math.pow(10, tier-1)).toLocaleString()} damage.`,
       type: AchievementTypes.COMBAT,
       rewards
     }];

--- a/src/plugins/achievements/achievements/Walker.js
+++ b/src/plugins/achievements/achievements/Walker.js
@@ -27,7 +27,7 @@ export class Walker extends Achievement {
     return [{
       tier,
       name: 'Walker',
-      desc: `Gain +${tier} Bonus XP (added every time XP is gained) for taking ${Math.pow(10, tier)} steps.`,
+      desc: `Gain +${tier} Bonus XP (added every time XP is gained) for taking ${(Math.pow(10, tier)).toLocaleString()} steps.`,
       type: AchievementTypes.EXPLORE,
       rewards
     }];


### PR DESCRIPTION
used .toLocaleString() to insert commas (or fullstops in parts of
europe) to any large numbers in the achievements text.

We CAN force locales with this, but it’s not supported in all browsers.
This will default to something vaguely sensible, and appears to be well
supported:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global
_Objects/Number/toLocaleString#Browser_compatibility