### PR TITLE
Stop char stats proxy concatenating 3 lists every time a stat is read

### DIFF
--- a/src/core/base/character.js
+++ b/src/core/base/character.js
@@ -11,7 +11,8 @@ import { Equipment } from '../base/equipment';
 import { SpellManager } from '../../plugins/combat/spellmanager';
 import { EffectManager } from '../../plugins/combat/effectmanager';
 
-import { StatCalculator, BASE_STATS, SPECIAL_STATS, ATTACK_STATS } from '../../shared/stat-calculator';
+import { StatCalculator } from '../../shared/stat-calculator';
+import { Generator } from './generator.js';
 
 export class Character {
 
@@ -46,7 +47,7 @@ export class Character {
 
     this.$stats = new Proxy({}, {
       get: (target, name) => {
-        if(_.includes(BASE_STATS.concat(SPECIAL_STATS).concat(ATTACK_STATS), name)) {
+        if(_.includes(Generator.stats, name)) {
           return StatCalculator.stat(this, name);
         }
 


### PR DESCRIPTION
Generator already does the concat one. It’s not going to change mid
game. No point doing 3x concats for every single stat retrieval.

Is debatable whether a const in the top of this file would be more
efficient than referencing the entire Generator class. Likely sub
optimal to have the same code in two places though.