### PR TITLE
don't log non errors in pickRandomTile

### DIFF
--- a/src/plugins/players/player.js
+++ b/src/plugins/players/player.js
@@ -201,16 +201,16 @@ export class Player extends Character {
     let [index, newLoc, dir] = this.$playerMovement.pickRandomTile(this, weight);
     let tile = this.$playerMovement.getTileAt(this.map, newLoc.x, newLoc.y);
 
-    let attempts = 0;
+    let attempts = 1;
     while(!this.$playerMovement.canEnterTile(this, tile)) {
+      if (attempts > 8) {
+        Logger.error('Player', `Player ${this.name} is position locked at ${this.x}, ${this.y} in ${this.map}`);
+        break;
+      }
       weight[index] = 0;
       [index, newLoc, dir] = this.$playerMovement.pickRandomTile(this, weight, true);
       tile = this.$playerMovement.getTileAt(this.map, newLoc.x, newLoc.y);
       attempts++;
-      if (attempts >7) {
-        Logger.error('Player', `Player ${this.name} is position locked at ${this.x}, ${this.y} in ${this.map}`);
-        break;
-      }
     }
 
     this.lastDir = dir === 5 ? null : dir;

--- a/src/plugins/players/player.movement.js
+++ b/src/plugins/players/player.movement.js
@@ -197,8 +197,7 @@ export class PlayerMovement {
 
     const indexes = [0, 1, 2, 3, 4, 5, 6, 7];
 
-    let randomIndex = 0;
-    randomIndex = chance.weighted(indexes, weight);
+    const randomIndex = chance.weighted(indexes, weight);
     const dir = directions[randomIndex];
 
     return [randomIndex, this.num2dir(dir, player.x, player.y), dir];


### PR DESCRIPTION
Off by one error. Checking for “player surrounded by 8 non-valid tiles”
in the wrong position.