### PR TITLE
replace not overwrite player timeouts

### DIFF
--- a/src/core/game-state.js
+++ b/src/core/game-state.js
@@ -33,6 +33,9 @@ export class GameState {
   }
 
   _setTimeout(playerName, timeoutId) {
+    if (this.playerTimeouts[playerName]) {
+      clearTimeout(this.playerTimeouts[playerName]);
+    }
     this.playerTimeouts[playerName] = timeoutId;
   }
 


### PR DESCRIPTION
In fast login/out situations, we can end up with multiple timeouts set per player.

If it exists, clear the previous one, rather than leaving it running & losing the id.

Should help with players inadvertently being logged out (and thus seeing the “welcome back” message).