### PR TITLE
if player has logged out, won't be in gamestate list

### DIFF
--- a/src/plugins/combat/battle.socket.js
+++ b/src/plugins/combat/battle.socket.js
@@ -10,6 +10,7 @@ export const socket = (socket, primus, respond) => {
   const retrieve = async({ battleName, playerName }) => {
     try {
       const battle = await retrieveFromDb(battleName);
+      if (!battle) return;
       DataUpdater(playerName, 'battle', battle);
     } catch(e) {
       respond(e);

--- a/src/plugins/gm/teleport.socket.js
+++ b/src/plugins/gm/teleport.socket.js
@@ -13,7 +13,7 @@ export const socket = (socket) => {
     const { playerName } = socket.authToken;
 
     const player = GameState.getInstance().getPlayer(playerName);
-    if(!player.isMod) return;
+    if(!player || !player.isMod) return;
 
     const target = GameState.getInstance().getPlayer(targetName);
     GMCommands.teleport(target, teleData);

--- a/src/plugins/gm/toggleachievement.socket.js
+++ b/src/plugins/gm/toggleachievement.socket.js
@@ -13,7 +13,7 @@ export const socket = (socket) => {
     const { playerName } = socket.authToken;
 
     const player = GameState.getInstance().getPlayer(playerName);
-    if(!player.isMod) return;
+    if(!player || !player.isMod) return;
 
     const target = GameState.getInstance().getPlayer(targetName);
     GMCommands.toggleAchievement(target, achievement);

--- a/src/plugins/gm/togglemode.socket.js
+++ b/src/plugins/gm/togglemode.socket.js
@@ -13,7 +13,7 @@ export const socket = (socket) => {
     const { playerName } = socket.authToken;
 
     const player = GameState.getInstance().getPlayer(playerName);
-    if(!player.isMod) return;
+    if(!player || !player.isMod) return;
 
     const target = GameState.getInstance().getPlayer(targetName);
     GMCommands.toggleMod(target);

--- a/src/plugins/pets/pet.attr.socket.js
+++ b/src/plugins/pets/pet.attr.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.changePetAttr(player, newAttr);
   };
 

--- a/src/plugins/pets/pet.buy.socket.js
+++ b/src/plugins/pets/pet.buy.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.addNewPet(player, petType, petName);
   };
 

--- a/src/plugins/pets/pet.equipment.unequip.socket.js
+++ b/src/plugins/pets/pet.equipment.unequip.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket, primus, respond) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     const message = player.$pets.unequipPetItem(player, itemId);
 
     if(message) {

--- a/src/plugins/pets/pet.feed.socket.js
+++ b/src/plugins/pets/pet.feed.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket, primus, respond) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     const message = player.$pets.feedGold(player, gold);
 
     if(message) {

--- a/src/plugins/pets/pet.inventory.equip.socket.js
+++ b/src/plugins/pets/pet.inventory.equip.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket, primus, respond) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     const message = player.$pets.equipPetItem(player, itemId);
 
     if(message) {

--- a/src/plugins/pets/pet.inventory.sell.socket.js
+++ b/src/plugins/pets/pet.inventory.sell.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.sellPetItem(player, itemId);
   };
 

--- a/src/plugins/pets/pet.profession.socket.js
+++ b/src/plugins/pets/pet.profession.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.changePetProfession(player, newProfession);
   };
 

--- a/src/plugins/pets/pet.smart.socket.js
+++ b/src/plugins/pets/pet.smart.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.togglePetSmartSetting(setting);
   };
 

--- a/src/plugins/pets/pet.swap.socket.js
+++ b/src/plugins/pets/pet.swap.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.changePet(player, petType);
   };
 

--- a/src/plugins/pets/pet.takeGold.socket.js
+++ b/src/plugins/pets/pet.takeGold.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.takePetGold(player);
   };
 

--- a/src/plugins/pets/pet.upgrade.socket.js
+++ b/src/plugins/pets/pet.upgrade.socket.js
@@ -13,7 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
-
+    if(!player) return;
+    
     player.$pets.upgradePet(player, upgradeAttr);
   };
 

--- a/src/plugins/players/player.choice.socket.js
+++ b/src/plugins/players/player.choice.socket.js
@@ -13,6 +13,7 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
+    if (!player) return;
     player.handleChoice({ id, response });
   };
 

--- a/src/plugins/players/player.gender.socket.js
+++ b/src/plugins/players/player.gender.socket.js
@@ -13,6 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
+    if(!player) return;
+    
     player.changeGender(gender);
   };
 

--- a/src/plugins/players/player.personality.socket.js
+++ b/src/plugins/players/player.personality.socket.js
@@ -13,6 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
+    if(!player) return;
+    
     player.togglePersonality(personality);
   };
 

--- a/src/plugins/players/player.title.socket.js
+++ b/src/plugins/players/player.title.socket.js
@@ -13,6 +13,8 @@ export const socket = (socket) => {
     if(!playerName) return;
 
     const player = GameState.getInstance().getPlayer(playerName);
+    if(!player) return;
+    
     player.changeTitle(title);
   };
 


### PR DESCRIPTION
In fast log in/out situations, we can get delayed/lagged or confused messages from the client. This results in us trying to find a player that doesn’t exist in our official list (i.e., we’ve already logged them out & removed them from gamestate.players).

Just stop the whole thing puking. Throw out the client message.