### PR TITLE
get babel installed before use

### DIFF
--- a/scripts/prod-prep.sh
+++ b/scripts/prod-prep.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+npm install --save babel-cli
+
 # obviously we could also put our babel command in here, to create the dist subtree, thusly:
 babel -q --compact true --minified -d /app/dist /app/src
 


### PR DESCRIPTION
(this should - I would have thought - have been pulled in with the rest of the node_modules, but apparently not). Slowly slowly.