### PR TITLE
Upon beating boss party, return boss names rather than boss party name.

### DIFF
--- a/src/plugins/events/events/BattleBoss.js
+++ b/src/plugins/events/events/BattleBoss.js
@@ -55,8 +55,8 @@ export class BattleBoss extends Event {
       _.each(player.party.players, p => {
         if(!p.$statistics) return;
     
-        _.each(_.keys(bosses), (boss) => {
-          p.$statistics.incrementStat(`Character.BossKills.${boss}`);
+        _.each(bosses, boss => {
+          p.$statistics.incrementStat(`Character.BossKills.${boss._name}`);
         });
       });
 

--- a/src/plugins/events/events/BattleBoss.js
+++ b/src/plugins/events/events/BattleBoss.js
@@ -54,10 +54,10 @@ export class BattleBoss extends Event {
     if(!battle.isLoser(player.party) && !battle._isTie) {
       _.each(player.party.players, p => {
         if(!p.$statistics) return;
-		
-		_.each(_.keys(bosses), (boss) => {
-			p.$statistics.incrementStat(`Character.BossKills.${boss}`);
-		});
+    
+      _.each(_.keys(bosses), (boss) => {
+        p.$statistics.incrementStat(`Character.BossKills.${boss}`);
+      });
       });
 
       MonsterGenerator._setBossTimer(bossName);

--- a/src/plugins/events/events/BattleBoss.js
+++ b/src/plugins/events/events/BattleBoss.js
@@ -55,9 +55,9 @@ export class BattleBoss extends Event {
       _.each(player.party.players, p => {
         if(!p.$statistics) return;
     
-      _.each(_.keys(bosses), (boss) => {
-        p.$statistics.incrementStat(`Character.BossKills.${boss}`);
-      });
+        _.each(_.keys(bosses), (boss) => {
+          p.$statistics.incrementStat(`Character.BossKills.${boss}`);
+        });
       });
 
       MonsterGenerator._setBossTimer(bossName);

--- a/src/plugins/events/events/BattleBoss.js
+++ b/src/plugins/events/events/BattleBoss.js
@@ -54,7 +54,10 @@ export class BattleBoss extends Event {
     if(!battle.isLoser(player.party) && !battle._isTie) {
       _.each(player.party.players, p => {
         if(!p.$statistics) return;
-        p.$statistics.incrementStat(`Character.BossKills.${bossName}`);
+		
+		_.each(_.keys(bosses), (boss) => {
+			p.$statistics.incrementStat(`Character.BossKills.${boss}`);
+		});
       });
 
       MonsterGenerator._setBossTimer(bossName);

--- a/src/shared/monster-generator.js
+++ b/src/shared/monster-generator.js
@@ -35,6 +35,7 @@ export class MonsterGenerator extends Generator {
     const boss = _.cloneDeep(Bosses[name]);
     if(!this._isBossAlive(name)) return;
     boss.stats.name = name;
+    boss.stats._name = name;
     const monster = this.augmentMonster(boss.stats);
     monster.$isBoss = true;
     this.equipBoss(monster, boss.items);
@@ -48,6 +49,7 @@ export class MonsterGenerator extends Generator {
     return _.map(bossparty.members, member => {
       const boss = _.cloneDeep(Bosses[member]);
       boss.stats.name = member;
+      boss.stats._name = member;
       const monster = this.augmentMonster(boss.stats);
       this.equipBoss(monster, boss.items);
       monster._collectibles = boss.collectibles;

--- a/src/shared/monster-generator.js
+++ b/src/shared/monster-generator.js
@@ -34,8 +34,8 @@ export class MonsterGenerator extends Generator {
   static generateBoss(name) {
     const boss = _.cloneDeep(Bosses[name]);
     if(!this._isBossAlive(name)) return;
-    boss.stats.name = name;
-    boss.stats._name = name;
+    boss.stats.name = `${name}`;
+    boss.stats._name = `${name}`;
     const monster = this.augmentMonster(boss.stats);
     monster.$isBoss = true;
     this.equipBoss(monster, boss.items);
@@ -48,8 +48,8 @@ export class MonsterGenerator extends Generator {
     if(!this._isBossAlive(name)) return;
     return _.map(bossparty.members, member => {
       const boss = _.cloneDeep(Bosses[member]);
-      boss.stats.name = member;
-      boss.stats._name = member;
+      boss.stats.name = `${member}`;
+      boss.stats._name = `${member}`;
       const monster = this.augmentMonster(boss.stats);
       this.equipBoss(monster, boss.items);
       monster._collectibles = boss.collectibles;

--- a/src/shared/monster-generator.js
+++ b/src/shared/monster-generator.js
@@ -47,7 +47,7 @@ export class MonsterGenerator extends Generator {
     if(!this._isBossAlive(name)) return;
     return _.map(bossparty.members, member => {
       const boss = _.cloneDeep(Bosses[member]);
-      boss.stats.name = name;
+      boss.stats.name = member;
       const monster = this.augmentMonster(boss.stats);
       this.equipBoss(monster, boss.items);
       monster._collectibles = boss.collectibles;


### PR DESCRIPTION
Rather than their actual names, bosses still seem to use their party name (if they have one,) in combat logs. Therefore, they still return with Character.BossKills.Wardens (for example,) but it does go through and increment once for each boss. Now all that's left is to fix it so they use their actual names rather than their party names.