### PR TITLE
Fixed XPForsake event text

### DIFF
--- a/src/plugins/events/events/XPForsake.js
+++ b/src/plugins/events/events/XPForsake.js
@@ -10,12 +10,12 @@ export class XPForsake extends Event {
 
   static operateOn(player) {
     const percent = Event.chance.floating({ fixed: 5, min: 0.03, max: 0.05 });
-    const xpMod = Math.floor(player._xp.maximum * percent);
+    const baseXP = Math.floor(player._xp.maximum * percent);
+	const xpMod = player.gainXP(-baseXP);
     const eventText = this.eventText('forsakeXp', player, { xp: xpMod });
 
-    this.emitMessage({ affected: [player], eventText: `${eventText} [-${xpMod} xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
-    player.gainXp(-xpMod);
-
+    this.emitMessage({ affected: [player], eventText: `${eventText} [-${Math.abs(xpMod)} xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });
+	
     return [player];
   }
 }

--- a/src/plugins/events/events/XPForsake.js
+++ b/src/plugins/events/events/XPForsake.js
@@ -11,7 +11,7 @@ export class XPForsake extends Event {
   static operateOn(player) {
     const percent = Event.chance.floating({ fixed: 5, min: 0.03, max: 0.05 });
     const baseXP = Math.floor(player._xp.maximum * percent);
-	const xpMod = player.gainXP(-baseXP);
+    const xpMod = player.gainXP(-baseXP);
     const eventText = this.eventText('forsakeXp', player, { xp: xpMod });
 
     this.emitMessage({ affected: [player], eventText: `${eventText} [-${Math.abs(xpMod)} xp, ~${(percent*100).toFixed(2)}%]`, category: MessageCategories.XP });


### PR DESCRIPTION
It was displaying the amount of xp before it was modified by personalities, so I updated it to be like XPBless. I put Math.abs(xpMod) in the event text rather than just xpMod, to hopefully change as little as possible on the surface.