### PR TITLE
Actually fix battle xp this time

### DIFF
--- a/src/plugins/combat/battle.js
+++ b/src/plugins/combat/battle.js
@@ -187,14 +187,9 @@ export class Battle {
   get winningTeam() {
     return _.filter(this.parties, party => _.some(party.players, p => this.isPlayerAlive(p)))[0];
   }
-
-  get winners() {
-    return this.winningTeam.players;
-  }
-
-  get losers() {
-    const winners = this.winners;
-    return _.filter(this.allPlayers, p => !_.includes(winners, p));
+  
+  get losingTeam() {
+    return _.filter(this.parties, party => party !== this.winningTeam)[0];
   }
 
   isLoser(party) {
@@ -232,7 +227,7 @@ export class Battle {
 
         this._emitMessage(`${party.displayName} won!`);
 
-        const compareLevel = _.sum(_.map(this.losers, 'level')) / this.losers.length;
+        const compareLevel = this.losingTeam.level;
         const level = party.level;
         const levelDiff = Math.max(-5, Math.min(5, compareLevel - level)) + 6;
 
@@ -255,7 +250,7 @@ export class Battle {
         _.each(party.players, p => {
           this.tryIncrement(p, 'Combat.Lose');
 
-          const compareLevel = _.sum(_.map(this.winners, 'level')) / this.winners.length;
+          const compareLevel = this.winningTeam.level;
           const currentGold = _.isNumber(p.gold) ? p.gold : p.gold.__current;
           const lostGold = Math.round(currentGold / 100);
           let lostXp = Math.round(p._xp.maximum / 20);

--- a/src/plugins/combat/battle.js
+++ b/src/plugins/combat/battle.js
@@ -231,7 +231,7 @@ export class Battle {
         const level = party.level;
         const levelDiff = Math.max(-5, Math.min(5, compareLevel - level)) + 6;
 
-        const goldGainedInParty = Math.round((compareLevel * 1560) / party.players.length);
+        const goldGainedInParty = Math.round((compareLevel * 1560) / _.reject(party.players, (p) => p.$isMinion).length);
 
         _.each(party.players, p => {
           this.tryIncrement(p, 'Combat.Win');

--- a/src/plugins/party/party.js
+++ b/src/plugins/party/party.js
@@ -27,21 +27,27 @@ export class Party {
   }
 
   get score() {
-    if (leader.isPlayer) {
-      return _.sum(_.map(this.humanPlayers, 'itemScore')) / this.humanPlayers.length;
+    let score = 0;
+    
+    if (this.leader.isPlayer) {
+      score = _.sum(_.map(this.humanPlayers, 'itemScore')) / this.humanPlayers.length;
+    } else {
+      score = _.sum(_.map(this.players, 'itemScore')) / this.players.length;
     }
-    else {
-      return _.sum(_.map(this.players, 'itemScore')) / this.players.length;
-    }
+    
+    return score;
   }
 
   get level() {
-    if (leader.isPlayer) {
-      return _.sum(_.map(this.humanPlayers, 'level')) / this.humanPlayers.length;
+    let level = 0;
+    
+    if (this.leader.isPlayer) {
+      level = _.sum(_.map(this.humanPlayers, 'level')) / this.humanPlayers.length;
+    } else {
+      level = _.sum(_.map(this.players, 'level')) / this.players.length;
     }
-    else {
-      return _.sum(_.map(this.players, 'level')) / this.players.length;
-    }
+    
+    return level;
   }
 
   get displayName() {

--- a/src/plugins/party/party.js
+++ b/src/plugins/party/party.js
@@ -21,13 +21,27 @@ export class Party {
 
     this.playerJoin(leader);
   }
+  
+  get humanPlayers() {
+    return _.filter(this.players, player => player.isPlayer);
+  }
 
   get score() {
-    return _.sum(_.map(_.filter(this.players, player => player.isPlayer), 'itemScore')) / this.players.length;
+    if (leader.isPlayer) {
+      return _.sum(_.map(this.humanPlayers, 'itemScore')) / this.humanPlayers.length;
+    }
+    else {
+      return _.sum(_.map(this.players, 'itemScore')) / this.players.length;
+    }
   }
 
   get level() {
-    return _.sum(_.map(_.filter(this.players, player => player.isPlayer), 'level')) / this.players.length;
+    if (leader.isPlayer) {
+      return _.sum(_.map(this.humanPlayers, 'level')) / this.humanPlayers.length;
+    }
+    else {
+      return _.sum(_.map(this.players, 'level')) / this.players.length;
+    }
   }
 
   get displayName() {


### PR DESCRIPTION
Unfortunately my last PR only checked for players' levels, but still divided by all the total number of party members when calculating party level.

I fixed `Party.level` so it gives an accurate party level, but I had to put in an if to check if the leader was human, so non-player parties can still calculate their level.

I also removed `get winners()` and `get losers()` from battle.js, added `get losingTeam()`, then used `this.losingTeam.level` and `this.winningTeam.level` instead of using `this.winners` and `this.losers` to calculate the parties' levels. Should make `endBattleBonuses()` a tad easier to read, and this way any changes that need to be made to party level calculations can be done in `Party.level`

I was gone for most of today and when I got back it seemed like nobody was around, so I'm still not sure how to set up the .env file (or what it is/does,) and I don't know how to test this before submitting. Of course, I'm hoping it'll work, but if it doesn't, then I guess I'll just have to wait 'til I figure out how to test it.