### PR TITLE
Fix several necromancer bugs

### DIFF
--- a/src/core/professions/Lich.js
+++ b/src/core/professions/Lich.js
@@ -21,7 +21,6 @@ export class Lich extends Profession {
   }
 
   static setupSpecial(target) {
-    target.$battle.kill = true;
     const numProfessions = Math.floor(target.level / 50) + 1;
     target.$secondaryProfessions = _.sampleSize(['Bard', 'Cleric', 'Fighter', 'Generalist', 'Mage', 'SandwichArtist'], numProfessions);
     target._special.name = 'Phylactic Energy';

--- a/src/plugins/combat/battle.js
+++ b/src/plugins/combat/battle.js
@@ -225,14 +225,15 @@ export class Battle {
 
     _.each(this.parties, party => {
       // no monster bonuses
-      if(!party.leader.isPlayer) return;
+      // rare edge case with Bonecraft reducing loser's party size to one summon and then killing it.
+      if(!party.leader || !party.leader.isPlayer) return;
 
       // if this team won
       if(this.winningTeam === party) {
 
         this._emitMessage(`${party.displayName} won!`);
 
-        const compareLevel = _.sum(_.map(this.losers, 'level')) / this.losers.length;
+        const compareLevel = _.sum(_.map(this.losers, 'level')) / Math.max(this.losers.length, 1);
         const level = party.level;
         const levelDiff = Math.max(-5, Math.min(5, compareLevel - level)) + 6;
 

--- a/src/plugins/combat/spells/Bonecraft.js
+++ b/src/plugins/combat/spells/Bonecraft.js
@@ -24,7 +24,9 @@ export class Bonecraft extends Spell {
     _.each(targets, target => {
       const damage = -Math.round(target._hp.maximum * this.spellPower/100);
 
-      target.$prevParty = target.party;
+      if(!target.$prevParty) {
+        target.$prevParty = target.party;
+      }
       target.party.playerLeave(target);
       this.caster.party.playerJoin(target);
 

--- a/src/plugins/combat/spells/Bonecraft.js
+++ b/src/plugins/combat/spells/Bonecraft.js
@@ -10,11 +10,11 @@ export class Bonecraft extends Spell {
   ];
 
   static shouldCast(caster) {
-    return this.$canTarget.anyEnemyDead(caster);
+    return this.$canTarget.anyBonecraftable(caster);
   }
 
   determineTargets() {
-    return this.$targetting.randomDeadEnemy;
+    return this.$targetting.randomBonecraftable;
   }
 
   preCast() {

--- a/src/plugins/combat/spells/Summon.js
+++ b/src/plugins/combat/spells/Summon.js
@@ -72,8 +72,8 @@ export class Summon extends Spell {
 
     summonedMonster._eventSelfKilled = () => {
       this.caster._special.sub(baseMonster.slotCost);
-      this.caster.party.playerLeave(summonedMonster);
-      this._emitMessage(this.caster, '%targetName exploded into a pile of arcane dust!', { targetName: summonedMonster.fullname });
+      summonedMonster.party.playerLeave(summonedMonster);
+      summonedMonster.$battle._emitMessage(this._emitMessage(this.caster, '%targetName exploded into a pile of arcane dust!', { targetName: summonedMonster.fullname }));
     };
 
     const message = `%player used %spellName and spawned a ${baseMonster.name}!`;

--- a/src/plugins/combat/spelltargetpossibilities.js
+++ b/src/plugins/combat/spelltargetpossibilities.js
@@ -36,6 +36,15 @@ export class SpellTargetPossibilities {
         .value().length >= 1;
   }
 
+  // Dead and not bonecrafted before
+  static anyBonecraftable(caster) {
+    return _(caster.$battle.allPlayers)
+        .reject(p => p.hp > 0)
+        .reject(p => p.party === caster.party)
+        .reject(p => p.$prevParty)
+        .value().length >= 1;
+  }
+
   static allyWithoutEffect(caster, effect) {
     return _(caster.$battle.allPlayers)
         .reject(p => p.hp === 0)

--- a/src/plugins/combat/spelltargetstrategy.js
+++ b/src/plugins/combat/spelltargetstrategy.js
@@ -68,6 +68,15 @@ export class SpellTargetStrategy {
       .sample()];
   }
 
+  // Dead enemy and not bonecrafted before
+  static randomBonecraftable(caster) {
+    return [_(caster.$battle.allPlayers)
+      .reject(p => p.hp > 0)
+      .reject(p => p.party === caster.party)
+      .reject(p => p.$prevParty)
+      .sample()];
+  }
+
   static allAllies(caster) {
     return _(caster.$battle.allPlayers)
       .reject(p => p.hp === 0)


### PR DESCRIPTION
* Summons now use their death message. Closes #478
* Summons correctly remove themselves from the party if their summoner gets Bonecrafted. Closes #474
* Bonecraft now tracks the original party, not the previous one. Closes #479
* Fix a bug where bonecrafting an entire party and then killing the last summon would break battle rewards.

* Battle debug no longer exits when a Lich is killed.