### PR TITLE
use hp getter instead of __current for venom

### DIFF
--- a/src/plugins/combat/effects/Venom.js
+++ b/src/plugins/combat/effects/Venom.js
@@ -13,7 +13,7 @@ export class Venom extends Effect {
 
   tick() {
     super.tick();
-    const damage = Math.round(this.target._hp.__current * 0.02 * this.potency);
+    const damage = Math.round(this.target.hp * 0.02 * this.potency);
     const message = '%player suffered %damage damage from %casterName\'s %spellName!';
     this.dealDamage(this.target, damage, message);
   }


### PR DESCRIPTION
Tahu mentioned that current hp has a getter and that it would be better to use that than to directly access __current. It passed the lint thing and everything worked as intended on the test server.