### PR TITLE
Changed summon spell & floored Antimagic Arrow mp reduction

### DIFF
--- a/src/plugins/combat/spells/AntimagicArrow.js
+++ b/src/plugins/combat/spells/AntimagicArrow.js
@@ -32,7 +32,7 @@ export class AntimagicArrow extends Spell {
     _.each(targets, target => {
       const damage = this.calcDamage();
 
-      const lostMp = target._mp.maximum * (25 * (this.spellPower+1)/100);
+      const lostMp = Math.floor(target._mp.maximum * (25 * (this.spellPower+1)/100));
       target._mp.sub(lostMp);
       const message = `%player used an %spellName on %targetName and dealt %damage damage and reduced %targetName\'s mp by ${lostMp}!`;
 

--- a/src/plugins/combat/spells/Summon.js
+++ b/src/plugins/combat/spells/Summon.js
@@ -21,12 +21,19 @@ const monsters = {
     {
       name: 'dracolich',
       statMult: 1.35,
-      slotCost: 2,
+      slotCost: 4,
       restrictLevel: 85,
-      baseStats: { mirror: 1 },
+      restrictClasses: ['Lich'],
       requireCollectibles: ['Undead Dragon Scale']
     },
-    { name: 'demogorgon', statMult: 1.75, slotCost: 4, restrictLevel: 150, requireCollectibles: ['Gorgon Snake'] }
+    {
+      name: 'demogorgon',
+      statMult: 1.75,
+      slotCost: 6,
+      restrictLevel: 150,
+      baseStats: { mirror: 1 },
+      requireCollectibles: ['Gorgon Snake']
+    }
   ]
 };
 
@@ -54,7 +61,6 @@ export class Summon extends Spell {
 
   preCast() {
     const baseMonster = _.cloneDeep(this.chooseValidMonster());
-    baseMonster.level = Math.floor(this.caster.level / 2);
     _.extend(baseMonster, baseMonster.baseStats);
 
     if(baseMonster.restrictClasses) {
@@ -66,6 +72,7 @@ export class Summon extends Spell {
     const summonedMonster = MonsterGenerator.augmentMonster(baseMonster, mimicTarget);
     summonedMonster.name = `${this.caster.fullname}'s ${summonedMonster.name}`;
     summonedMonster.$isMinion = true;
+    summonedMonster._level.set(Math.floor(this.caster.level/2));
 
     this.caster.party.playerJoin(summonedMonster);
     this.caster.$battle._setupPlayer(summonedMonster);


### PR DESCRIPTION
Dracoliches no longer mirror players. Instead, they always spawn as liches. Raised slot cost from 2 to 4.
Demogorgons now mirror players. Raised slot cost from 4 to 6.

Antimagic Arrow's mp reduction has been floored, so mp should only be reduced by whole numbers now.