### PR TITLE
Fixed and changed drunk movement.

### DIFF
--- a/src/plugins/players/player.movement.js
+++ b/src/plugins/players/player.movement.js
@@ -205,18 +205,19 @@ export class PlayerMovement {
   }
 
   static getInitialWeight(player) {
-  
-    let weight = [300, 40, 7,  3,  1,  3,  7,  40];
-    
     const MAX_DRUNK = 10;
     const drunkFromPersonality = player.$personalities.isActive('Drunk') ? 7 : 0;
     const drunk = Math.max(0, Math.min(MAX_DRUNK, drunkFromPersonality));
-
-    if(player.lastDir && !drunk) {
+    
+    let weight = [300, 40, 7,  3,  1,  3,  7,  40]; // Sober: 75% 10%  2% <1% <1% <1%  2% 10%
+    
+    if(drunk) {
+      weight = [100, 40, 30, 20, 20, 20, 30, 40];   // Drunk: 33% 13% 10%  7%  7%  7% 10% 13%
+    }
+    
+    if(player.lastDir) {
       const lastDirIndex = directions.indexOf(player.lastDir);
       weight = weight.slice(weight.length - lastDirIndex).concat(weight.slice(0, weight.length - lastDirIndex));
-    } else if(drunk) {
-      weight = _.map(weight, s => Math.max(1, 200 - (s * (1 - drunk / MAX_DRUNK))));
     }
 
     return weight;


### PR DESCRIPTION
Drunk movement now considers previous movement direction.

I also changed the drunk weights to a simple, hard-coded array that favors forward movement (to a degree,) but is otherwise largely normalized.

I can't see the players on the map to see if they're moving as intended, but everything ran fine, so I don't see why they wouldn't be.