### PR TITLE
Archer tweaks.

### DIFF
--- a/src/core/professions/Archer.js
+++ b/src/core/professions/Archer.js
@@ -6,7 +6,8 @@ export class Archer extends Profession {
   static baseHpPerLevel = Profession.baseHpPerLevel + 15;
   static baseMpPerLevel = Profession.baseMpPerLevel + 10;
 
-  static baseHpPerDex = 3;
+  static baseHpPerCon = 3;
+  static baseHpPerDex = 1;
   static baseMpPerDex = 3;
 
   static baseConPerLevel = 2;

--- a/src/plugins/combat/spells/AntimagicArrow.js
+++ b/src/plugins/combat/spells/AntimagicArrow.js
@@ -17,8 +17,8 @@ export class AntimagicArrow extends Spell {
   }
 
   calcDamage() {
-    const min = (this.caster.liveStats.int + this.caster.liveStats.dex) * 0.4;
-    const max = (this.caster.liveStats.int + this.caster.liveStats.dex) * 0.7;
+    const min = (this.caster.liveStats.int + (this.caster.liveStats.dex * 0.25)) * 0.2;
+    const max = (this.caster.liveStats.int + (this.caster.liveStats.dex * 0.25)) * 0.4;
     return this.minMax(min, max) * this.spellPower;
   }
 

--- a/src/plugins/combat/spells/Multishot.js
+++ b/src/plugins/combat/spells/Multishot.js
@@ -16,8 +16,8 @@ export class Multishot extends Spell {
   }
 
   calcDamage() {
-    const min = this.caster.liveStats.dex * (0.2*this.spellPower+0.8);
-    const max = this.caster.liveStats.dex * (0.5*this.spellPower+0.8);
+    const min = this.caster.liveStats.dex * 0.25;
+    const max = this.caster.liveStats.dex * 0.50;
     return this.minMax(min, max);
   }
 

--- a/src/plugins/combat/spells/Shattershot.js
+++ b/src/plugins/combat/spells/Shattershot.js
@@ -8,8 +8,8 @@ export class Shattershot extends Spell {
   static element = SpellType.PHYSICAL;
   static stat = 'special';
   static tiers = [
-    { name: 'shattershot',   spellPower: 2, weight: 30, cost: 25,  level: 25,  profession: 'Archer' },
-    { name: 'shatterblast',  spellPower: 3, weight: 30, cost: 35,  level: 65,  profession: 'Archer' }
+    { name: 'shattershot',   spellPower: 1, weight: 30, cost: 25,  level: 25,  profession: 'Archer' },
+    { name: 'shatterblast',  spellPower: 2, weight: 30, cost: 35,  level: 65,  profession: 'Archer' }
   ];
 
   static shouldCast(caster) {
@@ -21,9 +21,9 @@ export class Shattershot extends Spell {
   }
 
   calcDamage() {
-    const min = (this.caster.liveStats.str + this.caster.liveStats.dex) * 0.75;
-    const max = (this.caster.liveStats.str + this.caster.liveStats.dex) * 1.50;
-    return this.minMax(min, max) * (this.spellPower-1);
+    const min = (this.caster.liveStats.str + (this.caster.liveStats.dex * 0.5)) * 0.2;
+    const max = (this.caster.liveStats.str + (this.caster.liveStats.dex * 0.5)) * 0.4;
+    return this.minMax(min, max) * (this.spellPower);
   }
 
   calcDuration() {
@@ -47,7 +47,7 @@ export class Shattershot extends Spell {
         targets: [target]
       });
 
-      super.applyCombatEffects(_.sampleSize(ATTACK_STATS, this.spellPower), target);
+      super.applyCombatEffects(_.sampleSize(ATTACK_STATS, this.spellPower+1), target);
     });
   }
 }


### PR DESCRIPTION
This is an attempt to balance archers. Feedback welcome.

Archer hp/con reduced from 5 to 3, archer hp/dex reduced from 3 to 1.
Shattershot damage greatly reduced. Scales with str and dex, but favors str.
Antimagic Arrow damage greatly reduced. Scales with int and dex, but favors int.
Multishot damage greatly reduced. Spellpower now only benefits number of shots, not damage.