### PR TITLE
Can't Flip the Bit on bosses, boss party bosses flagged as bosses.

### DIFF
--- a/src/plugins/combat/spells/FlipTheBit.js
+++ b/src/plugins/combat/spells/FlipTheBit.js
@@ -10,11 +10,11 @@ export class FlipTheBit extends Spell {
   ];
 
   static shouldCast(caster) {
-    return this.$canTarget.enemyNotProfession(caster, 'Bitomancer');
+    return this.$canTarget.anyBitFlippable(caster);
   }
 
   determineTargets() {
-    return this.$targetting.randomEnemyNotProfession('Bitomancer');
+    return this.$targetting.randomBitFlippable;
   }
 
   preCast() {

--- a/src/plugins/combat/spelltargetpossibilities.js
+++ b/src/plugins/combat/spelltargetpossibilities.js
@@ -45,6 +45,16 @@ export class SpellTargetPossibilities {
         .value().length >= 1;
   }
 
+  // Not a boss, not a bitomancer
+  static anyBitFlippable(caster) {
+    return _(caster.$battle.allPlayers)
+        .reject(p => p.hp > 0)
+        .reject(p => p.party === caster.party)
+        .reject(p => p.$isBoss)
+        .reject(p => p.professionName === 'Bitomancer')
+        .value().length >= 1;
+  }
+
   static allyWithoutEffect(caster, effect) {
     return _(caster.$battle.allPlayers)
         .reject(p => p.hp === 0)

--- a/src/plugins/combat/spelltargetstrategy.js
+++ b/src/plugins/combat/spelltargetstrategy.js
@@ -82,6 +82,16 @@ export class SpellTargetStrategy {
       .reject(p => p.$prevParty)
       .sample()];
   }
+  
+  // Not boss, not bitomancer
+  static randomBitFlippable(caster) {
+    return [_(caster.$battle.allPlayers)
+      .reject(p => p.hp > 0)
+      .reject(p => p.party === caster.party)
+      .reject(p => p.$isBoss)
+      .reject(p => p.professionName === 'Bitomancer')
+      .sample()];
+  }
 
   static allAllies(caster) {
     return _(caster.$battle.allPlayers)

--- a/src/shared/monster-generator.js
+++ b/src/shared/monster-generator.js
@@ -51,6 +51,7 @@ export class MonsterGenerator extends Generator {
       boss.stats.name = `${member}`;
       boss.stats._name = `${member}`;
       const monster = this.augmentMonster(boss.stats);
+      monster.$isBoss = true;
       this.equipBoss(monster, boss.items);
       monster._collectibles = boss.collectibles;
       return monster;


### PR DESCRIPTION
Added targetting functions in spelltargetpossibilities and spelltargetstrategy for Flip the Bit, that rejects bosses as well as bitomancers.

Boss party bosses weren't being flagged as bosses (`$isBoss`) during creation. As such, I expect they were affected by DebuffTouch and stuns like a normal enemy. If this was desired behavior, let me know, it won't take long to fix. This PR flags all boss party bosses as such, so they should no longer be affected by stuns, targeted by FlipTheBit, or damaged directly by DebuffTouch.