### PR TITLE
Adding Vitriol

### DIFF
--- a/src/core/base/equipment.js
+++ b/src/core/base/equipment.js
@@ -38,6 +38,7 @@ export class Equipment {
     damageReductionPercent: 1000,
     gold: 0.5,
     sentimentality: 1,
+    vitriol: -1,
     dance: 100,
     defense: 100,
     offense: 100,

--- a/src/shared/stat-calculator.js
+++ b/src/shared/stat-calculator.js
@@ -19,6 +19,7 @@ export const SPECIAL_STATS_BASE = [
   { name: 'vorpal',          desc: '+10% critical chance.', enchantMax: 1 },
   { name: 'glowing',         desc: '+5% to all physical combat rolls. Stacks intensity.', enchantMax: 1 },
   { name: 'sentimentality',  desc: '+1 score. Stacks intensity.', enchantMax: 500 },
+  { name: 'vitriol',         desc: '-1 score. Stacks intensity.', enchantMax 500 },
   { name: 'hp',              desc: '+1 hp. Stacks intensity.', enchantMax: 2000 },
   { name: 'mp',              desc: '+1 mp. Stacks intensity.', enchantMax: 2000 },
   { name: 'hpregen',         desc: 'Regenerate HP every combat round. Stacks intensity.', enchantMax: 100 },


### PR DESCRIPTION
The negative version of sentimentality (removes item score).
Adding it as a separate thing because negative sentimentality doesn't always stay that way when vectored.