### PR TITLE
Prevent party formation in some regions

### DIFF
--- a/src/shared/regions.js
+++ b/src/shared/regions.js
@@ -101,5 +101,11 @@ export const Regions = {
   'Norkos Fisheries Area': {
     BattleChance:       (player, baseValue) => baseValue*1.2,
     BattlePvPChance:    (player, baseValue) => baseValue*1.2
+  },
+  'King\'s Treasure Room': {
+    PartyChance:        (player, baseValue) => baseValue*0
+  },
+  'Chamber of Ascension': {
+    PartyChance:        (player, baseValue) => baseValue*0
   }
 };


### PR DESCRIPTION
Certain regions or locations require collectibles to access and parties forming there can get players stuck