### PR TITLE
Generalize Change

### DIFF
--- a/src/server/core/game/professions/Generalist.ts
+++ b/src/server/core/game/professions/Generalist.ts
@@ -49,7 +49,7 @@ export class Generalist extends BaseProfession implements IProfession {
   public oocAbility(player: Player): { success: boolean, message: string } {
     const scaler = player.$statistics.get('Profession/Generalist/Become') || 1;
 
-    const luk = Math.max(Math.floor(player.getStat(Stat.LUK) * 2.5 * Math.log(scaler)), player.getStat(Stat.LUK))
+    const luk = Math.max(Math.floor(player.getStat(Stat.LUK) * 2.5 * Math.log(scaler)), player.getStat(Stat.LUK));
 
     const xpGained = Math.max(player.gainXP(luk), 10);
     this.emitProfessionMessage(player, `You gained ${xpGained.toLocaleString()} XP via Generalize!`);

--- a/src/server/core/game/professions/Generalist.ts
+++ b/src/server/core/game/professions/Generalist.ts
@@ -49,7 +49,7 @@ export class Generalist extends BaseProfession implements IProfession {
   public oocAbility(player: Player): { success: boolean, message: string } {
     const scaler = player.$statistics.get('Profession/Generalist/Become') || 1;
 
-    const luk = player.getStat(Stat.LUK) * scaler;
+    const luk = Math.max(Math.floor(player.getStat(Stat.LUK) * 2.5 * Math.log(scaler)), player.getStat(Stat.LUK))
 
     const xpGained = Math.max(player.gainXP(luk), 10);
     this.emitProfessionMessage(player, `You gained ${xpGained.toLocaleString()} XP via Generalize!`);


### PR DESCRIPTION
Change to generalizer to stop it continuing to increase linearly with becomes, and bring it a bit closer in line with Experiencer.  The factor of 2.5 makes it close to Experiencer for a given number of becomes/Luck but can be tweaked if it doesn't seem right.  The Math.max is needed to catch the issue of Log(1) being zero. Of course, feel free to chuck the whole idea out and do it yourself too if you have a refinement or this doesn't work how I think it does. Also please check carefully as I'm fairly inexperienced.