### PR TITLE
Add drop shadow for white ion-icons

### DIFF
--- a/src/client/global.scss
+++ b/src/client/global.scss
@@ -207,3 +207,8 @@ ion-progress-bar {
 .gold {
   color: gold;
 }
+
+ion-icon.ion-color-light{
+    -webkit-filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, .6));
+    filter: drop-shadow(0px 0px 1px rgba(0, 0, 0, .6));
+}


### PR DESCRIPTION
Should resolve #130  
Updated to only apply to light icons