### PR TITLE
Sort global contributions in descending order

### DIFF
--- a/src/shared/models/entity/Quests.entity.ts
+++ b/src/shared/models/entity/Quests.entity.ts
@@ -178,7 +178,7 @@ export class Quests extends PlayerOwned {
 
     player.increaseStatistic(`Quest/Global/Map/${quest.objectives[0].requireMap}`, 1);
 
-    const maxContributions = sortBy(Object.keys(totalSums), pl => totalSums[pl]);
+    const maxContributions = sortBy(Object.keys(totalSums), pl => -totalSums[pl]);
 
     let rewardKey = 'other';
     if(maxContributions[0] === player.name) {


### PR DESCRIPTION
Lodash's sortBy function sorts in ascending order ([documentation](https://lodash.com/docs/4.17.15#sortBy)), so the last place contribution was getting the 1st place reward. Negating the key is sufficient to sort in descending order.