### PR TITLE
Fix extra 1 second in festival times

### DIFF
--- a/src/server/core/game/festival-manager.ts
+++ b/src/server/core/game/festival-manager.ts
@@ -67,7 +67,8 @@ export class FestivalManager {
       second: 1
     };
 
-    let duration = ((festival.endTime - Date.now()) / 1000) + 1;
+    const milliseconds = festival.endTime - Date.now();
+    let duration = Math.floor((milliseconds + 500) / 1000);
     const resp = { };
     const stamp = [];
 


### PR DESCRIPTION
Simply rounds to the nearest whole second. Previously 1700ms would report as 1 second.