### PR TITLE
Group crier messages

### DIFF
--- a/src/server/core/game/game.ts
+++ b/src/server/core/game/game.ts
@@ -180,6 +180,11 @@ export class Game implements IGame {
       this.guildManager.saveAll();
     }
 
+    // Send crier messages
+    if((this.ticks % 25) === 0) {
+      this.discordManager.dispatchCrier();
+    }
+
     Object.values(this.guildManager.allGuilds).forEach(guild => guild.loop(this));
 
     if((this.ticks % 100) === 0) {


### PR DESCRIPTION
Changes how guild messages are sent to discord to prevent rate limiting.  
Instead of sending 1 message per line it will store the lines and send them in groups of 10 so that 15 lines (15 messages) would become 2 messages (still 15 lines).  
  
![1](https://i.imgur.com/DJPdzur.png)  
