### PR TITLE
Prevent type error when StripeCheckout is undefined

### DIFF
--- a/src/client/app/premium/premium.page.ts
+++ b/src/client/app/premium/premium.page.ts
@@ -95,7 +95,7 @@ export class PremiumPage implements OnInit {
 
   private initStripe() {
     setTimeout(() => {
-      this.stripeCheckoutHandler = (<any>window).StripeCheckout.configure({
+      this.stripeCheckoutHandler = (<any>window).StripeCheckout?.configure({
         key: environment.stripe.apiKey,
         name: 'IdleLands',
         allowRememberMe: true,


### PR DESCRIPTION
StripeCheckout can be undefined if the Stripe script is blocked or unavailable for some reason