### PR TITLE
Nerf premium gold collectibles

### DIFF
--- a/src/server/modules/premium.ts
+++ b/src/server/modules/premium.ts
@@ -107,6 +107,9 @@ export class PremiumCollectibleBuy extends ServerSocketEvent implements ServerEv
     const target = PremiumGoldCollectibleInfo[collectible];
     if(!target) return this.gameError('Unable to find collectible information.');
 
+    const touches = this.player.$collectibles.get(target.name).touched;
+    if(touches > (this.player.ascensionLevel + 1)*100) return this.gameError('You can only buy 100 of each premium collectible per ascension.');
+
     player.tryFindCollectible(target);
     player.spendGold(cost, false);
 

--- a/src/server/modules/premium.ts
+++ b/src/server/modules/premium.ts
@@ -108,7 +108,7 @@ export class PremiumCollectibleBuy extends ServerSocketEvent implements ServerEv
     if(!target) return this.gameError('Unable to find collectible information.');
 
     const touches = this.player.$collectibles.get(target.name).touched;
-    if(touches > (this.player.ascensionLevel + 1)*100) return this.gameError('You can only buy 100 of each premium collectible per ascension.');
+    if(touches >= (this.player.ascensionLevel + 1)*100) return this.gameError('You can only buy 100 of each premium collectible per ascension.');
 
     player.tryFindCollectible(target);
     player.spendGold(cost, false);

--- a/src/shared/models/entity/Player.entity.ts
+++ b/src/shared/models/entity/Player.entity.ts
@@ -1115,8 +1115,9 @@ export class Player implements IPlayer {
   }
 
   public tryFindCollectible({ name, rarity, description, storyline }) {
-
-    this.increaseStatistic('Item/Collectible/Touch', 1);
+    if (storyline != 'Premium store.') {
+      this.increaseStatistic('Item/Collectible/Touch', 1);
+    }
 
     let currentCollectible = this.$collectibles.get(name);
 

--- a/src/shared/models/entity/Player.entity.ts
+++ b/src/shared/models/entity/Player.entity.ts
@@ -1115,9 +1115,8 @@ export class Player implements IPlayer {
   }
 
   public tryFindCollectible({ name, rarity, description, storyline }) {
-    if (storyline != 'Premium store.') {
-      this.increaseStatistic('Item/Collectible/Touch', 1);
-    }
+
+    this.increaseStatistic('Item/Collectible/Touch', 1);
 
     let currentCollectible = this.$collectibles.get(name);
 


### PR DESCRIPTION
To stop high-frequency traffic to the server to buy pots of gold to fulfill quests, this patch limits the amount of premium gold collectibles by 100 per ascension. This still keeps it useful for people that want to use them once in a while, but discourages scripting and hopefully improve the server's health.